### PR TITLE
Add memoization to speed up searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 ## Dependencies
 
-This plugin relies on `wmctrl` package, which needs to be installed prior.
+This plugin relies on `wmctrl` package, which needs to be installed prior. It also relies on the Python `memoization` package being available.
+
 
 ## Usage
 

--- a/main.py
+++ b/main.py
@@ -8,10 +8,12 @@ from ulauncher.api.shared.action.RunScriptAction import RunScriptAction
 
 import subprocess
 
+from memoization import cached
 
 ACTIVATE_COMMAND = 'wmctrl -i -a {}'
 
 
+@cached(ttl=5)
 def list_windows():
     """List the windows being managed by the window manager.
 
@@ -46,6 +48,7 @@ def list_windows():
     return windows
 
 
+@cached(ttl=15)
 def get_process_name(pid):
     """Find out process name, given its' ID
 


### PR DESCRIPTION
Hi,

This extension seems very useful to me, but I find it too slow to actually use atm. I thus cached the `wmctrl` calls with the `memoization` module to speed this up significantly. 

This does add an additional dependency, but it's also used by comparable ULauncher extensions such as https://github.com/brpaz/ulauncher-brotab