### PR TITLE
Disclude ulauncher from switch dialogue

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,13 +37,14 @@ def list_windows():
         pid = info[2]
         host = info[3]
         title = ' '.join(info[4:])
-        windows.append({
-            'id': window_id,
-            'desktop': desktop_num,
-            'pid': pid,
-            'host': host,
-            'title': title
-        })
+        if title != "Ulauncher - Application Launcher":
+            windows.append({
+                'id': window_id,
+                'desktop': desktop_num,
+                'pid': pid,
+                'host': host,
+                'title': title
+            })
 
     return windows
 


### PR DESCRIPTION
I really like this extension, but for me, it's one glaring issue is that it includes the ulauncher window in it's dialogue. This is how I fixed that